### PR TITLE
use mounted directory for Blazegraph data to prevent data loss

### DIFF
--- a/blazegraph/RWStore.properties
+++ b/blazegraph/RWStore.properties
@@ -9,7 +9,7 @@
 # The backing file. This contains all your data.  You want to put this someplace
 # safe.  The default locator will wind up in the directory from which you start
 # your servlet container.
-com.bigdata.journal.AbstractJournal.file=bigdata.jnl
+com.bigdata.journal.AbstractJournal.file=/data/blazegraph/bigdata.jnl
 
 # The persistence engine.  Use 'Disk' for the WORM or 'DiskRW' for the RWStore.
 com.bigdata.journal.AbstractJournal.bufferMode=DiskRW


### PR DESCRIPTION
The datafile used by Blazegraph was not part of the mounted `/data` directory, thus data will be lost when rebuilding the container. However, when using `/data` as provided in this commit the following issue with permissions becomes relevant: https://github.com/viaacode/knowledge-graph-organizations/issues/2